### PR TITLE
Fix typo in sample usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ DiffJPEG functions as a standard pytorch module/layer.  To use, first import the
 
 ``` python
 from DiffJPEG import DiffJPEG
-jpeg = DiffJPEG(hieght=224, width=224, differentiable=True, quality=80)
+jpeg = DiffJPEG(height=224, width=224, differentiable=True, quality=80)
 ```
 
 ![image](./diffjpeg.png)


### PR DESCRIPTION
`height` was typoed to `hieght`.

This means when trying to run the sample code one would get:

```
---------------------------------------------------------------------------

TypeError                                 Traceback (most recent call last)

[<ipython-input-15-0aa60d9f7322>](https://localhost:8080/#) in <module>
      1 from DiffJPEG import DiffJPEG
----> 2 jpeg = DiffJPEG(hieght=224, width=224, differentiable=True, quality=80)
      3 
      4 class PGD_JPEG(attacks.PGD):
      5     """

TypeError: __init__() got an unexpected keyword argument 'hieght'
```